### PR TITLE
feat(#92): Generic Workload Adapter + Execution Runtime

### DIFF
--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -214,3 +214,23 @@ export interface ToolRepository {
   remove(id: string): boolean;
   syncFromFileSystem(toolsPath: string): Promise<void>;
 }
+
+export interface WorkloadAdapterRecord {
+  readonly id: string;
+  readonly name: string;
+  readonly type: string;
+  readonly config: string;
+  readonly isActive: boolean;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}
+
+export interface WorkloadAdapterRepository {
+  create(adapter: Omit<WorkloadAdapterRecord, "id" | "isActive" | "createdAt" | "updatedAt"> & { isActive?: boolean }): WorkloadAdapterRecord;
+  findAll(): WorkloadAdapterRecord[];
+  findById(id: string): WorkloadAdapterRecord | undefined;
+  findActive(): WorkloadAdapterRecord | undefined;
+  update(id: string, updates: Partial<Omit<WorkloadAdapterRecord, "id" | "createdAt">>): boolean;
+  setActive(id: string): boolean;
+  remove(id: string): boolean;
+}

--- a/src/execution/content-parser.ts
+++ b/src/execution/content-parser.ts
@@ -1,0 +1,126 @@
+function parseScalar(raw: string): unknown {
+  const value = raw.trim();
+  if (value === "") return "";
+  if (value === "true") return true;
+  if (value === "false") return false;
+  if (value === "null") return null;
+  if (/^-?\d+(\.\d+)?$/.test(value)) return Number(value);
+  if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+function parseSimpleYaml(content: string): unknown {
+  const lines = content
+    .split("\n")
+    .map((line) => line.replace(/\t/g, "  "))
+    .filter((line) => line.trim() !== "" && !line.trimStart().startsWith("#"));
+
+  if (lines.length === 0) {
+    return {};
+  }
+
+  const root: Record<string, unknown> = {};
+  const stack: Array<{ indent: number; container: unknown }> = [{ indent: -1, container: root }];
+
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+    const line = lines[lineIndex];
+    const indent = line.match(/^\s*/)?.[0].length ?? 0;
+    const trimmed = line.trim();
+
+    while (stack.length > 1 && indent <= stack[stack.length - 1].indent) {
+      stack.pop();
+    }
+
+    const parent = stack[stack.length - 1]?.container;
+
+    if (trimmed.startsWith("- ")) {
+      const itemBody = trimmed.slice(2);
+      if (!Array.isArray(parent)) {
+        throw new Error("Invalid YAML list structure");
+      }
+
+      if (itemBody.includes(":")) {
+        const [rawKey, ...rest] = itemBody.split(":");
+        const key = rawKey.trim();
+        const valueText = rest.join(":").trim();
+        const item: Record<string, unknown> = {};
+        item[key] = valueText === "" ? {} : parseScalar(valueText);
+        parent.push(item);
+        if (valueText === "") {
+          stack.push({ indent, container: item[key] });
+        } else {
+          stack.push({ indent, container: item });
+        }
+      } else {
+        parent.push(parseScalar(itemBody));
+      }
+
+      continue;
+    }
+
+    const [rawKey, ...rest] = trimmed.split(":");
+    const key = rawKey.trim();
+    const valueText = rest.join(":").trim();
+
+    if (!parent || Array.isArray(parent)) {
+      throw new Error("Invalid YAML object structure");
+    }
+
+    if (valueText === "") {
+      const nextLine = lines[lineIndex + 1];
+      const nextTrimmed = nextLine?.trim() ?? "";
+      const container: unknown = nextTrimmed.startsWith("- ") ? [] : {};
+      (parent as Record<string, unknown>)[key] = container;
+      stack.push({ indent, container });
+      continue;
+    }
+
+    (parent as Record<string, unknown>)[key] = parseScalar(valueText);
+  }
+
+  return root;
+}
+
+export function parseStructuredContent(content: string): unknown {
+  const trimmed = content.trim();
+
+  if (trimmed === "") {
+    return {};
+  }
+
+  if ((trimmed.startsWith("{") && trimmed.endsWith("}")) || (trimmed.startsWith("[") && trimmed.endsWith("]"))) {
+    return JSON.parse(trimmed) as unknown;
+  }
+
+  const yamlBody = trimmed.startsWith("---")
+    ? trimmed
+        .split("\n")
+        .slice(1)
+        .join("\n")
+    : trimmed;
+
+  return parseSimpleYaml(yamlBody);
+}
+
+export function interpolateTemplate(value: string, params: Record<string, unknown>): string {
+  return value.replace(/\{\{\s*([\w.-]+)\s*\}\}/g, (_match: string, key: string) => {
+    const segments = key.split(".");
+    let current: unknown = params;
+
+    for (const segment of segments) {
+      if (current && typeof current === "object" && segment in (current as Record<string, unknown>)) {
+        current = (current as Record<string, unknown>)[segment];
+      } else {
+        return "";
+      }
+    }
+
+    if (typeof current === "string" || typeof current === "number" || typeof current === "boolean") {
+      return String(current);
+    }
+
+    return current === null || current === undefined ? "" : JSON.stringify(current);
+  });
+}

--- a/src/execution/skill-runner.test.ts
+++ b/src/execution/skill-runner.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi } from "vitest";
+import type { SkillRepository, ToolRepository } from "../db/types.js";
+import { SkillRunner } from "./skill-runner.js";
+import type { ToolExecutor } from "./tool-executor.js";
+
+const now = new Date().toISOString();
+
+describe("SkillRunner", () => {
+  it("executes steps sequentially", async () => {
+    const skills: SkillRepository = {
+      create: vi.fn(),
+      findAll: vi.fn().mockReturnValue([]),
+      findById: vi.fn().mockReturnValue({
+        id: "skill-1",
+        name: "Skill",
+        description: "",
+        fileName: "skill.json",
+        content: JSON.stringify({
+          steps: [
+            { id: "first", toolId: "tool-1", params: { a: 1 } },
+            { id: "second", toolId: "tool-2", params: { b: 2 } },
+          ],
+        }),
+        createdAt: now,
+        updatedAt: now,
+      }),
+      findByFileName: vi.fn(),
+      update: vi.fn(),
+      remove: vi.fn(),
+      syncFromFileSystem: vi.fn(),
+    };
+
+    const tools: ToolRepository = {
+      create: vi.fn(),
+      findAll: vi.fn().mockReturnValue([]),
+      findById: vi.fn((id: string) => ({
+        id,
+        name: id,
+        description: "",
+        fileName: `${id}.json`,
+        content: JSON.stringify({ type: "shell", command: "echo ok" }),
+        createdAt: now,
+        updatedAt: now,
+      })),
+      findByFileName: vi.fn(),
+      update: vi.fn(),
+      remove: vi.fn(),
+      syncFromFileSystem: vi.fn(),
+    };
+
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce({ success: true, output: "one" })
+      .mockResolvedValueOnce({ success: true, output: "two" });
+
+    const runner = new SkillRunner({
+      skills,
+      tools,
+      toolExecutor: { execute } as unknown as ToolExecutor,
+    });
+
+    const result = await runner.executeSkill("skill-1");
+
+    expect(result.success).toBe(true);
+    expect(result.output).toEqual(["one", "two"]);
+    expect(execute).toHaveBeenCalledTimes(2);
+  });
+
+  it("applies profile parameters", async () => {
+    const skills: SkillRepository = {
+      create: vi.fn(),
+      findAll: vi.fn().mockReturnValue([]),
+      findById: vi.fn().mockReturnValue({
+        id: "skill-1",
+        name: "Skill",
+        description: "",
+        fileName: "skill.json",
+        content: JSON.stringify({
+          steps: [{ id: "build", toolId: "tool-1", params: { mode: "default" } }],
+          profiles: {
+            fast: {
+              params: { retries: 1 },
+              stepParams: {
+                build: { mode: "fast" },
+              },
+            },
+          },
+        }),
+        createdAt: now,
+        updatedAt: now,
+      }),
+      findByFileName: vi.fn(),
+      update: vi.fn(),
+      remove: vi.fn(),
+      syncFromFileSystem: vi.fn(),
+    };
+
+    const tools: ToolRepository = {
+      create: vi.fn(),
+      findAll: vi.fn().mockReturnValue([]),
+      findById: vi.fn().mockReturnValue({
+        id: "tool-1",
+        name: "Tool 1",
+        description: "",
+        fileName: "tool-1.json",
+        content: JSON.stringify({ type: "shell", command: "echo ok" }),
+        createdAt: now,
+        updatedAt: now,
+      }),
+      findByFileName: vi.fn(),
+      update: vi.fn(),
+      remove: vi.fn(),
+      syncFromFileSystem: vi.fn(),
+    };
+
+    const execute = vi.fn().mockResolvedValue({ success: true, output: "done" });
+
+    const runner = new SkillRunner({
+      skills,
+      tools,
+      toolExecutor: { execute } as unknown as ToolExecutor,
+    });
+
+    const result = await runner.executeSkill("skill-1", { profile: "fast" });
+
+    expect(result.success).toBe(true);
+    expect(execute).toHaveBeenCalledWith(expect.objectContaining({
+      params: expect.objectContaining({ mode: "fast", retries: 1 }),
+      profile: "fast",
+    }));
+  });
+});

--- a/src/execution/skill-runner.ts
+++ b/src/execution/skill-runner.ts
@@ -1,0 +1,133 @@
+import type { SkillRepository, ToolRepository } from "../db/types.js";
+import { parseStructuredContent } from "./content-parser.js";
+import { ToolExecutor } from "./tool-executor.js";
+import type { SkillExecutionResult } from "./types.js";
+
+interface SkillStepDefinition {
+  readonly id?: string;
+  readonly toolId: string;
+  readonly params?: Record<string, unknown>;
+}
+
+interface SkillProfile {
+  readonly params?: Record<string, unknown>;
+  readonly stepParams?: Record<string, Record<string, unknown>>;
+}
+
+interface SkillDefinition {
+  readonly steps: SkillStepDefinition[];
+  readonly params?: Record<string, unknown>;
+  readonly profiles?: Record<string, SkillProfile>;
+}
+
+export interface SkillRunnerOptions {
+  readonly profile?: string;
+  readonly params?: Record<string, unknown>;
+}
+
+export interface SkillRunnerDeps {
+  readonly skills: SkillRepository;
+  readonly tools: ToolRepository;
+  readonly toolExecutor: ToolExecutor;
+}
+
+export class SkillRunner {
+  constructor(private readonly deps: SkillRunnerDeps) {}
+
+  async executeSkill(skillId: string, options: SkillRunnerOptions = {}): Promise<SkillExecutionResult> {
+    const skill = this.deps.skills.findById(skillId);
+    if (!skill) {
+      return {
+        success: false,
+        profile: options.profile,
+        steps: [],
+        output: [],
+        error: `Skill ${skillId} not found`,
+      };
+    }
+
+    const definition = this.parseSkillDefinition(skill.content);
+    const profileConfig = options.profile ? definition.profiles?.[options.profile] : undefined;
+
+    if (options.profile && !profileConfig) {
+      return {
+        success: false,
+        profile: options.profile,
+        steps: [],
+        output: [],
+        error: `Profile ${options.profile} not found for skill ${skill.name}`,
+      };
+    }
+
+    const stepResults: SkillExecutionResult["steps"] = [];
+    const output: unknown[] = [];
+
+    for (let index = 0; index < definition.steps.length; index += 1) {
+      const step = definition.steps[index];
+      const tool = this.deps.tools.findById(step.toolId);
+
+      if (!tool) {
+        return {
+          success: false,
+          profile: options.profile,
+          steps: stepResults,
+          output,
+          error: `Tool ${step.toolId} not found for step ${step.id ?? index + 1}`,
+        };
+      }
+
+      const stepId = step.id ?? `step-${index + 1}`;
+      const mergedParams: Record<string, unknown> = {
+        ...(definition.params ?? {}),
+        ...(profileConfig?.params ?? {}),
+        ...(step.params ?? {}),
+        ...(profileConfig?.stepParams?.[stepId] ?? {}),
+        ...(options.params ?? {}),
+      };
+
+      const result = await this.deps.toolExecutor.execute({
+        tool,
+        params: mergedParams,
+        profile: options.profile,
+      });
+
+      stepResults.push({
+        stepId,
+        toolId: tool.id,
+        result,
+      });
+      output.push(result.output);
+
+      if (!result.success) {
+        return {
+          success: false,
+          profile: options.profile,
+          steps: stepResults,
+          output,
+          error: result.error ?? `Step ${stepId} failed`,
+        };
+      }
+    }
+
+    return {
+      success: true,
+      profile: options.profile,
+      steps: stepResults,
+      output,
+    };
+  }
+
+  private parseSkillDefinition(content: string): SkillDefinition {
+    const parsed = parseStructuredContent(content);
+    if (!parsed || typeof parsed !== "object") {
+      throw new Error("Invalid skill definition: expected object");
+    }
+
+    const steps = (parsed as Record<string, unknown>).steps;
+    if (!Array.isArray(steps)) {
+      throw new Error("Invalid skill definition: steps array is required");
+    }
+
+    return parsed as SkillDefinition;
+  }
+}

--- a/src/execution/tool-executor.test.ts
+++ b/src/execution/tool-executor.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi } from "vitest";
+import type { ServiceRepository, Tool } from "../db/types.js";
+import { ToolExecutor } from "./tool-executor.js";
+
+function createTool(content: string): Tool {
+  const now = new Date().toISOString();
+  return {
+    id: "tool-1",
+    name: "Test Tool",
+    description: "",
+    fileName: "test-tool.json",
+    content,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+describe("ToolExecutor", () => {
+  it("executes shell tools", async () => {
+    const services: ServiceRepository = {
+      create: vi.fn(),
+      findAll: vi.fn().mockReturnValue([]),
+      findById: vi.fn(),
+      update: vi.fn(),
+      remove: vi.fn(),
+    };
+
+    const execCommand = vi.fn().mockReturnValue("hello shaun\n");
+    const executor = new ToolExecutor({ services, execCommand });
+
+    const result = await executor.execute({
+      tool: createTool(JSON.stringify({ type: "shell", command: "echo hello {{name}}" })),
+      params: { name: "shaun" },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.output).toBe("hello shaun\n");
+    expect(execCommand).toHaveBeenCalledWith("echo hello shaun", undefined);
+  });
+
+  it("executes http tools and resolves service config", async () => {
+    const services: ServiceRepository = {
+      create: vi.fn(),
+      findAll: vi.fn().mockReturnValue([]),
+      findById: vi.fn().mockReturnValue({
+        id: "svc-1",
+        name: "Service",
+        description: "",
+        provider: "",
+        baseUrl: "https://api.example.com",
+        authType: "none",
+        status: "active",
+        createdAt: "now",
+        updatedAt: "now",
+      }),
+      update: vi.fn(),
+      remove: vi.fn(),
+    };
+
+    const httpRequest = vi.fn().mockResolvedValue({ ok: true });
+    const executor = new ToolExecutor({ services, httpRequest });
+
+    const result = await executor.execute({
+      tool: createTool(JSON.stringify({
+        type: "http",
+        serviceId: "svc-1",
+        method: "POST",
+        path: "/v1/tasks/{{taskId}}",
+        body: { type: "sync" },
+      })),
+      params: { taskId: "92" },
+    });
+
+    expect(result.success).toBe(true);
+    expect(httpRequest).toHaveBeenCalledWith("https://api.example.com/v1/tasks/92", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ type: "sync" }),
+    });
+  });
+
+  it("returns failed result when tool execution throws", async () => {
+    const services: ServiceRepository = {
+      create: vi.fn(),
+      findAll: vi.fn().mockReturnValue([]),
+      findById: vi.fn(),
+      update: vi.fn(),
+      remove: vi.fn(),
+    };
+
+    const execCommand = vi.fn().mockImplementation(() => {
+      throw new Error("command failed");
+    });
+
+    const executor = new ToolExecutor({ services, execCommand });
+    const result = await executor.execute({
+      tool: createTool(JSON.stringify({ type: "shell", command: "exit 1" })),
+      params: {},
+      profile: "default",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("command failed");
+  });
+});

--- a/src/execution/tool-executor.ts
+++ b/src/execution/tool-executor.ts
@@ -1,0 +1,165 @@
+import { execSync } from "node:child_process";
+import type { Service, ServiceRepository, Tool } from "../db/types.js";
+import type { ExecutionResult, ToolExecutionContext } from "./types.js";
+import { interpolateTemplate, parseStructuredContent } from "./content-parser.js";
+
+interface ShellToolDefinition {
+  readonly type: "shell";
+  readonly command: string;
+  readonly cwd?: string;
+  readonly serviceId?: string;
+}
+
+interface HttpToolDefinition {
+  readonly type: "http";
+  readonly method?: string;
+  readonly url?: string;
+  readonly path?: string;
+  readonly headers?: Record<string, string>;
+  readonly body?: unknown;
+  readonly serviceId?: string;
+}
+
+type ToolDefinition = ShellToolDefinition | HttpToolDefinition;
+
+export interface ToolExecutorDeps {
+  readonly services: ServiceRepository;
+  readonly execCommand?: (command: string, cwd?: string) => string;
+  readonly httpRequest?: (url: string, init: RequestInit) => Promise<unknown>;
+}
+
+export class ToolExecutor {
+  private readonly execCommand: (command: string, cwd?: string) => string;
+  private readonly httpRequest: (url: string, init: RequestInit) => Promise<unknown>;
+
+  constructor(private readonly deps: ToolExecutorDeps) {
+    this.execCommand = deps.execCommand ?? ((command: string, cwd?: string) => execSync(command, {
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+      cwd,
+    }));
+
+    this.httpRequest = deps.httpRequest ?? (async (url: string, init: RequestInit) => {
+      const response = await fetch(url, init);
+      const contentType = response.headers.get("content-type") ?? "";
+      const output = contentType.includes("application/json")
+        ? await response.json()
+        : await response.text();
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${JSON.stringify(output)}`);
+      }
+
+      return output;
+    });
+  }
+
+  async execute(context: ToolExecutionContext): Promise<ExecutionResult> {
+    const definition = this.parseToolDefinition(context.tool);
+
+    try {
+      if (definition.type === "shell") {
+        return this.executeShellTool(definition, context.params);
+      }
+
+      return this.executeHttpTool(definition, context.params);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown tool execution error";
+      return {
+        success: false,
+        output: null,
+        error: message,
+        metadata: {
+          toolId: context.tool.id,
+          toolName: context.tool.name,
+          profile: context.profile,
+        },
+      };
+    }
+  }
+
+  private parseToolDefinition(tool: Tool): ToolDefinition {
+    const parsed = parseStructuredContent(tool.content);
+    if (!parsed || typeof parsed !== "object") {
+      throw new Error(`Invalid tool definition in ${tool.name}`);
+    }
+
+    const type = (parsed as Record<string, unknown>).type;
+    if (type !== "shell" && type !== "http") {
+      throw new Error(`Unsupported tool type for ${tool.name}`);
+    }
+
+    return parsed as ToolDefinition;
+  }
+
+  private resolveService(serviceId?: string): Service | undefined {
+    if (!serviceId) {
+      return undefined;
+    }
+
+    return this.deps.services.findById(serviceId);
+  }
+
+  private executeShellTool(definition: ShellToolDefinition, params: Record<string, unknown>): ExecutionResult {
+    const command = interpolateTemplate(definition.command, params);
+    const cwd = definition.cwd ? interpolateTemplate(definition.cwd, params) : undefined;
+
+    const output = this.execCommand(command, cwd);
+    return {
+      success: true,
+      output,
+      metadata: {
+        command,
+        cwd,
+      },
+    };
+  }
+
+  private async executeHttpTool(
+    definition: HttpToolDefinition,
+    params: Record<string, unknown>
+  ): Promise<ExecutionResult> {
+    const service = this.resolveService(definition.serviceId);
+    const serviceBaseUrl = service?.baseUrl ?? "";
+
+    const resolvedUrl = definition.url
+      ? interpolateTemplate(definition.url, params)
+      : `${serviceBaseUrl}${interpolateTemplate(definition.path ?? "", params)}`;
+
+    if (!resolvedUrl) {
+      throw new Error("HTTP tool requires a url or path/service baseUrl");
+    }
+
+    const headers: Record<string, string> = {
+      ...(definition.headers ?? {}),
+    };
+
+    const method = definition.method ?? "GET";
+
+    const init: RequestInit = {
+      method,
+      headers,
+    };
+
+    if (definition.body !== undefined) {
+      init.body = typeof definition.body === "string"
+        ? interpolateTemplate(definition.body, params)
+        : JSON.stringify(definition.body);
+      if (!headers["content-type"]) {
+        headers["content-type"] = "application/json";
+      }
+    }
+
+    const output = await this.httpRequest(resolvedUrl, init);
+
+    return {
+      success: true,
+      output,
+      metadata: {
+        method,
+        url: resolvedUrl,
+        serviceId: service?.id,
+      },
+    };
+  }
+}

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -1,0 +1,34 @@
+import type { Skill, Tool } from "../db/types.js";
+
+export interface ExecutionResult {
+  readonly success: boolean;
+  readonly output: unknown;
+  readonly error?: string;
+  readonly metadata?: Record<string, unknown>;
+}
+
+export interface ToolExecutionContext {
+  readonly tool: Tool;
+  readonly params: Record<string, unknown>;
+  readonly profile?: string;
+}
+
+export interface SkillStepExecutionResult {
+  readonly stepId: string;
+  readonly toolId: string;
+  readonly result: ExecutionResult;
+}
+
+export interface SkillExecutionContext {
+  readonly skill: Skill;
+  readonly profile?: string;
+  readonly params?: Record<string, unknown>;
+}
+
+export interface SkillExecutionResult {
+  readonly success: boolean;
+  readonly profile?: string;
+  readonly steps: SkillStepExecutionResult[];
+  readonly output: unknown[];
+  readonly error?: string;
+}

--- a/src/workload/adapter-registry.test.ts
+++ b/src/workload/adapter-registry.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { WorkloadAdapterRegistry } from "./adapter-registry.js";
+import type { WorkloadAdapter } from "./types.js";
+
+function createAdapter(name: string): WorkloadAdapter {
+  return {
+    getBacklog: async () => [{ id: `${name}-1`, title: "", description: "", status: "backlog", assignee: null, labels: [], url: "", source: name }],
+    getInProgress: async () => [],
+    getTicket: async () => undefined,
+    getMyWork: async () => [],
+    updateStatus: async () => true,
+  };
+}
+
+describe("WorkloadAdapterRegistry", () => {
+  it("registers and lists adapters", () => {
+    const registry = new WorkloadAdapterRegistry();
+    registry.register("github", createAdapter("github"), true);
+    registry.register("jira", createAdapter("jira"));
+
+    const list = registry.list();
+    expect(list).toHaveLength(2);
+    expect(list.find((item) => item.name === "github")?.isActive).toBe(true);
+  });
+
+  it("switches active adapter", () => {
+    const registry = new WorkloadAdapterRegistry();
+    registry.register("github", createAdapter("github"), true);
+    registry.register("jira", createAdapter("jira"));
+
+    expect(registry.setActive("jira")).toBe(true);
+    expect(registry.getActiveName()).toBe("jira");
+    expect(registry.setActive("missing")).toBe(false);
+  });
+});

--- a/src/workload/adapter-registry.ts
+++ b/src/workload/adapter-registry.ts
@@ -1,0 +1,45 @@
+import type { WorkloadAdapter } from "./types.js";
+
+export class WorkloadAdapterRegistry {
+  private readonly adapters = new Map<string, WorkloadAdapter>();
+  private activeAdapterName: string | null = null;
+
+  register(name: string, adapter: WorkloadAdapter, isActive = false): void {
+    this.adapters.set(name, adapter);
+
+    if (isActive || this.activeAdapterName === null) {
+      this.activeAdapterName = name;
+    }
+  }
+
+  list(): { name: string; isActive: boolean }[] {
+    return Array.from(this.adapters.keys())
+      .sort((a, b) => a.localeCompare(b))
+      .map((name) => ({ name, isActive: this.activeAdapterName === name }));
+  }
+
+  get(name: string): WorkloadAdapter | undefined {
+    return this.adapters.get(name);
+  }
+
+  getActiveName(): string | null {
+    return this.activeAdapterName;
+  }
+
+  getActiveAdapter(): WorkloadAdapter | undefined {
+    if (!this.activeAdapterName) {
+      return undefined;
+    }
+
+    return this.adapters.get(this.activeAdapterName);
+  }
+
+  setActive(name: string): boolean {
+    if (!this.adapters.has(name)) {
+      return false;
+    }
+
+    this.activeAdapterName = name;
+    return true;
+  }
+}

--- a/src/workload/github-adapter.test.ts
+++ b/src/workload/github-adapter.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from "vitest";
+import { GitHubWorkloadAdapter } from "./github-adapter.js";
+
+describe("GitHubWorkloadAdapter", () => {
+  it("loads backlog tickets via gh cli", async () => {
+    const exec = vi.fn().mockReturnValue(JSON.stringify([
+      {
+        number: 92,
+        title: "Workload adapter",
+        body: "Implement adapter",
+        state: "OPEN",
+        assignees: [{ login: "shaun" }],
+        labels: [{ name: "backlog" }],
+        url: "https://github.com/o/r/issues/92",
+      },
+    ]));
+
+    const adapter = new GitHubWorkloadAdapter("o", "r", undefined, { exec });
+    const tickets = await adapter.getBacklog();
+
+    expect(tickets).toHaveLength(1);
+    expect(tickets[0]).toMatchObject({
+      id: "92",
+      title: "Workload adapter",
+      status: "backlog",
+      assignee: "shaun",
+      source: "github",
+    });
+    expect(exec).toHaveBeenCalledWith(expect.stringContaining("gh issue list"));
+  });
+
+  it("returns ticket detail", async () => {
+    const exec = vi.fn().mockReturnValue(JSON.stringify({
+      number: 12,
+      title: "Issue 12",
+      body: "Details",
+      state: "OPEN",
+      assignees: [],
+      labels: [{ name: "in-progress" }],
+      url: "https://github.com/o/r/issues/12",
+    }));
+
+    const adapter = new GitHubWorkloadAdapter("o", "r", undefined, { exec });
+    const ticket = await adapter.getTicket("12");
+
+    expect(ticket).toMatchObject({
+      id: "12",
+      status: "in-progress",
+    });
+    expect(exec).toHaveBeenCalledWith(expect.stringContaining("gh issue view 12"));
+  });
+
+  it("updates status by adding label", async () => {
+    const exec = vi.fn().mockReturnValue("");
+
+    const adapter = new GitHubWorkloadAdapter("o", "r", undefined, { exec });
+    const updated = await adapter.updateStatus("45", "in-progress");
+
+    expect(updated).toBe(true);
+    expect(exec).toHaveBeenCalledWith(expect.stringContaining("gh issue edit 45"));
+  });
+});

--- a/src/workload/github-adapter.ts
+++ b/src/workload/github-adapter.ts
@@ -1,0 +1,130 @@
+import { execSync } from "node:child_process";
+import type { WorkloadAdapter, WorkloadTicket } from "./types.js";
+
+interface GitHubIssue {
+  readonly number: number;
+  readonly title: string;
+  readonly body?: string;
+  readonly state: string;
+  readonly assignees?: Array<{ readonly login: string }>;
+  readonly labels?: Array<{ readonly name: string }>;
+  readonly url: string;
+}
+
+export interface GitHubAdapterDeps {
+  readonly exec?: (command: string) => string;
+}
+
+export class GitHubWorkloadAdapter implements WorkloadAdapter {
+  private readonly exec: (command: string) => string;
+
+  constructor(
+    private readonly owner: string,
+    private readonly repo: string,
+    private readonly projectNumber?: number,
+    deps: GitHubAdapterDeps = {}
+  ) {
+    this.exec = deps.exec ?? ((command: string) => execSync(command, { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] }));
+  }
+
+  async getBacklog(): Promise<WorkloadTicket[]> {
+    const issues = this.listIssues('label:backlog');
+    return issues.map((issue) => this.mapIssue(issue));
+  }
+
+  async getInProgress(): Promise<WorkloadTicket[]> {
+    const issues = this.listIssues('label:"in-progress"');
+    return issues.map((issue) => this.mapIssue(issue));
+  }
+
+  async getTicket(id: string): Promise<WorkloadTicket | undefined> {
+    const issue = this.viewIssue(id);
+    if (!issue) {
+      return undefined;
+    }
+
+    return this.mapIssue(issue);
+  }
+
+  async getMyWork(): Promise<WorkloadTicket[]> {
+    const issues = this.listIssues("", "@me");
+    return issues.map((issue) => this.mapIssue(issue));
+  }
+
+  async updateStatus(id: string, status: string): Promise<boolean> {
+    try {
+      this.exec(`gh issue edit ${id} --repo ${this.owner}/${this.repo} --add-label ${JSON.stringify(status)}`);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private listIssues(search = "", assignee?: string): GitHubIssue[] {
+    const filters: string[] = [];
+    const searchTerms: string[] = [];
+
+    if (search) {
+      searchTerms.push(search);
+    }
+
+    if (assignee) {
+      filters.push(`--assignee ${assignee}`);
+    }
+
+    if (this.projectNumber !== undefined) {
+      searchTerms.push(`project:${this.projectNumber}`);
+    }
+
+    if (searchTerms.length > 0) {
+      filters.push(`--search ${JSON.stringify(searchTerms.join(" "))}`);
+    }
+
+    const command = [
+      `gh issue list`,
+      `--repo ${this.owner}/${this.repo}`,
+      `--state open`,
+      `--limit 100`,
+      `--json number,title,body,state,assignees,labels,url`,
+      ...filters,
+    ].join(" ");
+
+    const output = this.exec(command);
+    return JSON.parse(output) as GitHubIssue[];
+  }
+
+  private viewIssue(id: string): GitHubIssue | undefined {
+    try {
+      const output = this.exec(
+        `gh issue view ${id} --repo ${this.owner}/${this.repo} --json number,title,body,state,assignees,labels,url`
+      );
+      return JSON.parse(output) as GitHubIssue;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private mapIssue(issue: GitHubIssue): WorkloadTicket {
+    const labels = (issue.labels ?? []).map((label) => label.name);
+    const normalizedLabels = labels.map((label) => label.toLowerCase());
+
+    let status = issue.state.toLowerCase();
+    if (normalizedLabels.includes("backlog")) {
+      status = "backlog";
+    }
+    if (normalizedLabels.includes("in-progress")) {
+      status = "in-progress";
+    }
+
+    return {
+      id: String(issue.number),
+      title: issue.title,
+      description: issue.body ?? "",
+      status,
+      assignee: issue.assignees?.[0]?.login ?? null,
+      labels,
+      url: issue.url,
+      source: "github",
+    };
+  }
+}

--- a/src/workload/types.ts
+++ b/src/workload/types.ts
@@ -1,0 +1,18 @@
+export interface WorkloadTicket {
+  readonly id: string;
+  readonly title: string;
+  readonly description: string;
+  readonly status: string;
+  readonly assignee: string | null;
+  readonly labels: string[];
+  readonly url: string;
+  readonly source: string;
+}
+
+export interface WorkloadAdapter {
+  getBacklog(): Promise<WorkloadTicket[]>;
+  getInProgress(): Promise<WorkloadTicket[]>;
+  getTicket(id: string): Promise<WorkloadTicket | undefined>;
+  getMyWork(): Promise<WorkloadTicket[]>;
+  updateStatus(id: string, status: string): Promise<boolean>;
+}


### PR DESCRIPTION
## What

Implements the Generic Workload Adapter system (#92) plus the foundational execution runtime that all subsequent epic issues depend on.

### Execution Runtime (new `src/execution/`)
- **ToolExecutor** — runs shell commands and HTTP requests with DI for testing
- **SkillRunner** — sequential step execution with profile support and template interpolation
- **ContentParser** — YAML/JSON parser with `{{variable}}` template substitution

### Workload System (new `src/workload/`)
- **WorkloadAdapter** interface — generic contract for any ticket system
- **GitHubWorkloadAdapter** — first implementation using `gh` CLI
- **AdapterRegistry** — manages multiple adapters with active switching

### Database
- New `workload_adapters` table with CRUD via `SqliteWorkloadAdapterRepository`

### API Routes
- `POST /api/skills/:id/execute` — run a skill with optional profile/params
- `GET/POST /api/workload/adapters` — list adapters, set active
- `GET /api/workload/tickets` — query tickets (filter by status/assignee)
- `GET /api/workload/tickets/:id` — single ticket
- `GET /api/workload/backlog` + `/in-progress` — convenience endpoints
- `POST /api/workload/tickets/:id/status` — update ticket status

### Tests
183 tests pass (13 new across 4 new test files + extended existing suites).

Closes #92