### PR TITLE
feat(#94): Ticket Dashboard + Terminal Persistence

### DIFF
--- a/public/css/components.css
+++ b/public/css/components.css
@@ -1418,3 +1418,24 @@ select.form-input {
   color: var(--text-secondary);
   margin-top: var(--space-1);
 }
+/* Workload Dashboard */
+.workload-filters { display: flex; gap: var(--space-2); align-items: center; }
+.workload-container { display: flex; gap: var(--space-4); }
+.workload-list { flex: 1; display: flex; flex-direction: column; gap: var(--space-2); }
+.workload-detail { flex: 1; max-width: 50%; background: var(--surface-2); border-radius: var(--radius-lg); padding: var(--space-4); }
+.workload-ticket { background: var(--surface-2); border-radius: var(--radius-md); padding: var(--space-3); cursor: pointer; transition: background 0.15s; }
+.workload-ticket:hover { background: var(--surface-3); }
+.workload-ticket-header { display: flex; align-items: center; gap: var(--space-2); margin-bottom: var(--space-1); }
+.workload-ticket-title { font-weight: 500; color: var(--text-primary); }
+.workload-ticket-assignee { font-size: var(--text-sm); color: var(--text-secondary); }
+.workload-ticket-labels { display: flex; gap: var(--space-1); flex-wrap: wrap; margin-top: var(--space-1); }
+.workload-label { font-size: var(--text-xs); padding: 2px 8px; border-radius: var(--radius-sm); background: var(--surface-3); color: var(--text-secondary); }
+.workload-status-badge { font-size: var(--text-xs); padding: 2px 8px; border-radius: var(--radius-sm); font-weight: 600; text-transform: uppercase; }
+.workload-status-open, .workload-status-backlog { background: rgba(59, 130, 246, 0.2); color: #60a5fa; }
+.workload-status-in-progress, .workload-status-in_progress { background: rgba(245, 158, 11, 0.2); color: #fbbf24; }
+.workload-status-closed, .workload-status-done { background: rgba(34, 197, 94, 0.2); color: #4ade80; }
+.workload-status-unknown { background: rgba(107, 114, 128, 0.2); color: #9ca3af; }
+.workload-detail-header { display: flex; align-items: center; gap: var(--space-2); margin-bottom: var(--space-3); }
+.workload-detail-header h3 { margin: 0; }
+.workload-description { margin: var(--space-3) 0; white-space: pre-wrap; color: var(--text-secondary); }
+.workload-actions { display: flex; gap: var(--space-2); align-items: center; margin-top: var(--space-3); }

--- a/public/index.html
+++ b/public/index.html
@@ -84,6 +84,16 @@
             </a>
           </li>
           <li class="nav-item">
+            <a href="#" class="nav-link" data-section="workload" title="Workload">
+              <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                <rect x="3" y="3" width="7" height="7" rx="1"/>
+                <rect x="14" y="3" width="7" height="7" rx="1"/>
+                <rect x="3" y="14" width="7" height="7" rx="1"/>
+                <rect x="14" y="14" width="7" height="7" rx="1"/>
+              </svg>
+            </a>
+          </li>
+          <li class="nav-item">
             <a href="#" class="nav-link" data-section="agents" title="Agents">
               <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
                 <path d="M16 21v-2a4 4 0 00-4-4H8a4 4 0 00-4-4v2"/>
@@ -302,6 +312,33 @@
             <div class="split-list" id="servicesList"></div>
             <div class="split-detail" id="servicesDetail">
               <div class="detail-empty"><p>Select a service to view details</p></div>
+            </div>
+          </div>
+        </section>
+
+        <!-- Workload Section -->
+        <section id="workload-section" class="section">
+          <div class="section-header">
+            <h2 class="section-title">Workload</h2>
+            <div class="workload-filters">
+              <select id="workloadStatusFilter" class="form-select">
+                <option value="">All Statuses</option>
+                <option value="backlog">Backlog</option>
+                <option value="in-progress">In Progress</option>
+              </select>
+              <input type="text" id="workloadAssigneeFilter" class="form-input" placeholder="Filter by assignee..." />
+            </div>
+          </div>
+
+          <div class="workload-container">
+            <div class="workload-list" id="workloadList">
+              <div class="loading-spinner">
+                <div class="spinner"></div>
+                <p>Loading workload tickets...</p>
+              </div>
+            </div>
+            <div class="workload-detail" id="workloadDetail" style="display:none;">
+              <div class="workload-detail-content" id="workloadDetailContent"></div>
             </div>
           </div>
         </section>

--- a/src/index.ts
+++ b/src/index.ts
@@ -182,6 +182,16 @@ function handleWebSocketMessage(ws: WebSocket, message: any): void {
       }
       break;
 
+    case "terminal-reconnect": {
+      const sessions = terminalManager.reconnect(ws);
+      ws.send(JSON.stringify({
+        type: "terminal-reconnect-result",
+        sessions,
+      }));
+      logger.info({ count: sessions.length }, "Terminal reconnect completed");
+      break;
+    }
+
     default:
       logger.debug({ type: message.type }, "Unknown WebSocket message type");
   }

--- a/src/terminal/manager.test.ts
+++ b/src/terminal/manager.test.ts
@@ -197,7 +197,8 @@ describe("TerminalManager", () => {
         sessionId,
         exitCode: 0,
       }));
-      expect(manager.getSessionCount()).toBe(0);
+      // Session is kept for reconnect (marked as exited, not deleted)
+      expect(manager.getSessionCount()).toBe(1);
     });
 
     it("sends session created event", () => {
@@ -311,7 +312,7 @@ describe("TerminalManager", () => {
   });
 
   describe("killSessionsForWebSocket", () => {
-    it("kills all sessions for a WebSocket", () => {
+    it("keeps running sessions for reconnect on WebSocket disconnect", () => {
       const agent = createMockAgent("test", "Test");
       vi.mocked(mockAgentDefinitions.findPrimary).mockReturnValue(agent);
 
@@ -321,12 +322,13 @@ describe("TerminalManager", () => {
 
       expect(manager.getSessionCount()).toBe(2);
 
+      // Running sessions are kept for reconnect
       manager.killSessionsForWebSocket(mockWs);
 
-      expect(manager.getSessionCount()).toBe(1);
+      expect(manager.getSessionCount()).toBe(2);
       expect(mockLogger.info).toHaveBeenCalledWith(
         { sessionId: sessionId1 },
-        "Cleaning up session for disconnected WebSocket"
+        "Keeping running session for potential reconnect"
       );
     });
   });


### PR DESCRIPTION
## Ticket Dashboard
- Workload tab in nav with status-filtered ticket list
- Click ticket for detail panel (description, labels, status change)
- Filter by status and assignee

## Terminal Persistence
- 10KB scrollback buffer per session
- WS reconnect replays buffer and rebinds to running sessions
- Hybrid approach: reconnect if running, clean slate if exited

Closes #94