### PR TITLE
feat(#95): AI Acceptance Testing Framework

### DIFF
--- a/src/acceptance/ac-parser.ts
+++ b/src/acceptance/ac-parser.ts
@@ -1,0 +1,42 @@
+import type { AcceptanceCriterion } from "./types.js";
+
+export function parseAcceptanceCriteria(description: string): AcceptanceCriterion[] {
+  const criteria: AcceptanceCriterion[] = [];
+  const gwtPattern = /(?:^|\n)\s*(?:[-*]\s*)?(?:given|GIVEN)\s+(.+?)(?:\n\s*(?:[-*]\s*)?(?:when|WHEN)\s+(.+?))(?:\n\s*(?:[-*]\s*)?(?:then|THEN)\s+(.+?)(?=\n\s*(?:[-*]\s*)?(?:given|GIVEN|$)|\n\n|$))/gis;
+
+  let match: RegExpExecArray | null;
+  let index = 0;
+
+  while ((match = gwtPattern.exec(description)) !== null) {
+    index++;
+    criteria.push({
+      id: `ac-${index}`,
+      given: match[1]!.trim(),
+      when: match[2]!.trim(),
+      then: match[3]!.trim(),
+      raw: match[0].trim(),
+    });
+  }
+
+  if (criteria.length === 0) {
+    const acSection = description.match(/##?\s*(?:Acceptance\s*Criteria|AC)\s*\n([\s\S]*?)(?=\n##|\n$|$)/i);
+    if (acSection) {
+      const bullets = acSection[1]!.match(/^\s*[-*]\s+(.+)$/gm);
+      if (bullets) {
+        for (const bullet of bullets) {
+          index++;
+          const text = bullet.replace(/^\s*[-*]\s+/, "").trim();
+          criteria.push({
+            id: `ac-${index}`,
+            given: "the application is running",
+            when: "the user performs the described action",
+            then: text,
+            raw: text,
+          });
+        }
+      }
+    }
+  }
+
+  return criteria;
+}

--- a/src/acceptance/test-runner.test.ts
+++ b/src/acceptance/test-runner.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from "vitest";
+import { AcceptanceTestRunner, StubAcceptanceTestExecutor } from "./test-runner.js";
+import { parseAcceptanceCriteria } from "./ac-parser.js";
+import type { Logger } from "../logger.js";
+
+function mockLogger(): Logger {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), fatal: vi.fn(), trace: vi.fn(), child: vi.fn().mockReturnThis(), level: "silent", silent: vi.fn() } as unknown as Logger;
+}
+
+describe("parseAcceptanceCriteria", () => {
+  it("parses Given/When/Then format", () => {
+    const criteria = parseAcceptanceCriteria("Given the user is logged in\nWhen they click dashboard\nThen they see the dashboard");
+    expect(criteria).toHaveLength(1);
+    expect(criteria[0]!.given).toBe("the user is logged in");
+    expect(criteria[0]!.when).toBe("they click dashboard");
+    expect(criteria[0]!.then).toBe("they see the dashboard");
+  });
+
+  it("parses bullet-point AC", () => {
+    const criteria = parseAcceptanceCriteria("## Acceptance Criteria\n- Page loads fast\n- Error messages in red");
+    expect(criteria).toHaveLength(2);
+    expect(criteria[0]!.then).toBe("Page loads fast");
+  });
+
+  it("returns empty for no AC", () => {
+    expect(parseAcceptanceCriteria("Just a description.")).toHaveLength(0);
+  });
+});
+
+describe("AcceptanceTestRunner", () => {
+  it("runs with stub executor", async () => {
+    const runner = new AcceptanceTestRunner({ executor: new StubAcceptanceTestExecutor(), logger: mockLogger() });
+    const summary = await runner.run("T-1", "Test", "## Acceptance Criteria\n- Button exists\n- Page loads");
+    expect(summary.skipped).toBe(2);
+    expect(summary.passed).toBe(0);
+    expect(summary.markdown).toContain("Acceptance Test");
+  });
+
+  it("handles no AC", async () => {
+    const runner = new AcceptanceTestRunner({ executor: new StubAcceptanceTestExecutor(), logger: mockLogger() });
+    const summary = await runner.run("T-2", "No AC", "Just a description");
+    expect(summary.criteria).toHaveLength(0);
+    expect(summary.markdown).toContain("No acceptance criteria");
+  });
+});

--- a/src/acceptance/test-runner.ts
+++ b/src/acceptance/test-runner.ts
@@ -1,0 +1,70 @@
+import type { AcceptanceCriterion, AcceptanceTestExecutor, AcceptanceTestResult, AcceptanceTestSummary } from "./types.js";
+import { parseAcceptanceCriteria } from "./ac-parser.js";
+import type { Logger } from "../logger.js";
+
+export interface AcceptanceTestRunnerDeps {
+  readonly executor: AcceptanceTestExecutor;
+  readonly logger: Logger;
+}
+
+export class AcceptanceTestRunner {
+  constructor(private readonly deps: AcceptanceTestRunnerDeps) {}
+
+  async run(ticketId: string, ticketTitle: string, description: string, navigationSkill?: string): Promise<AcceptanceTestSummary> {
+    const criteria = parseAcceptanceCriteria(description);
+
+    if (criteria.length === 0) {
+      return {
+        ticketId, ticketTitle, generatedAt: new Date().toISOString(),
+        criteria, results: [], passed: 0, failed: 0, skipped: 0, errors: 0,
+        markdown: `# Acceptance Test: ${ticketTitle}\n\n⚠️ No acceptance criteria found in ticket description`,
+      };
+    }
+
+    const results: AcceptanceTestResult[] = [];
+
+    for (const criterion of criteria) {
+      this.deps.logger.info({ ticketId, criterionId: criterion.id }, "Running acceptance test");
+      try {
+        const result = await this.deps.executor.execute(criterion, navigationSkill);
+        results.push(result);
+      } catch (error) {
+        results.push({
+          criterionId: criterion.id, criterion, status: "error",
+          message: error instanceof Error ? error.message : "Unknown error", durationMs: 0,
+        });
+      }
+    }
+
+    const passed = results.filter(r => r.status === "pass").length;
+    const failed = results.filter(r => r.status === "fail").length;
+    const skipped = results.filter(r => r.status === "skip").length;
+    const errors = results.filter(r => r.status === "error").length;
+
+    const lines: string[] = [
+      `# Acceptance Test: ${ticketTitle}`, "",
+      `**Ticket:** ${ticketId}`,
+      `**Results:** ${passed} passed, ${failed} failed, ${skipped} skipped, ${errors} errors`, "",
+    ];
+
+    for (const r of results) {
+      const icon = r.status === "pass" ? "✅" : r.status === "fail" ? "❌" : r.status === "skip" ? "⏭️" : "💥";
+      lines.push(`## ${icon} ${r.criterionId}`);
+      lines.push(`**Given** ${r.criterion.given}`);
+      lines.push(`**When** ${r.criterion.when}`);
+      lines.push(`**Then** ${r.criterion.then}`, "");
+      lines.push(`**Status:** ${r.status} — ${r.message}`);
+      if (r.durationMs > 0) lines.push(`**Duration:** ${r.durationMs}ms`);
+      if (r.evidence?.length) { lines.push("**Evidence:**"); for (const e of r.evidence) lines.push(`- ${e}`); }
+      lines.push("");
+    }
+
+    return { ticketId, ticketTitle, generatedAt: new Date().toISOString(), criteria, results, passed, failed, skipped, errors, markdown: lines.join("\n") };
+  }
+}
+
+export class StubAcceptanceTestExecutor implements AcceptanceTestExecutor {
+  async execute(criterion: AcceptanceCriterion): Promise<AcceptanceTestResult> {
+    return { criterionId: criterion.id, criterion, status: "skip", message: "No browser automation configured — stub executor", durationMs: 0 };
+  }
+}

--- a/src/acceptance/types.ts
+++ b/src/acceptance/types.ts
@@ -1,0 +1,33 @@
+export interface AcceptanceCriterion {
+  readonly id: string;
+  readonly given: string;
+  readonly when: string;
+  readonly then: string;
+  readonly raw: string;
+}
+
+export interface AcceptanceTestResult {
+  readonly criterionId: string;
+  readonly criterion: AcceptanceCriterion;
+  readonly status: "pass" | "fail" | "skip" | "error";
+  readonly message: string;
+  readonly durationMs: number;
+  readonly evidence?: string[];
+}
+
+export interface AcceptanceTestSummary {
+  readonly ticketId: string;
+  readonly ticketTitle: string;
+  readonly generatedAt: string;
+  readonly criteria: AcceptanceCriterion[];
+  readonly results: AcceptanceTestResult[];
+  readonly passed: number;
+  readonly failed: number;
+  readonly skipped: number;
+  readonly errors: number;
+  readonly markdown: string;
+}
+
+export interface AcceptanceTestExecutor {
+  execute(criterion: AcceptanceCriterion, navigationSkill?: string): Promise<AcceptanceTestResult>;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { FileSystemDailySummaryExporter } from "./db/daily-summary-exporter.js";
 import { ToolExecutor } from "./execution/tool-executor.js";
 import { SkillRunner } from "./execution/skill-runner.js";
 import { StandupGenerator } from "./standup/standup-generator.js";
+import { AcceptanceTestRunner, StubAcceptanceTestExecutor } from "./acceptance/test-runner.js";
 import { TicketReviewer } from "./review/ticket-reviewer.js";
 import { WorkloadAdapterRegistry } from "./workload/adapter-registry.js";
 import { GitHubWorkloadAdapter } from "./workload/github-adapter.js";
@@ -113,6 +114,7 @@ const app = createApp({
   skillRunner,
   standupGenerator: new StandupGenerator(ticketActivity, tickets, logger),
   ticketReviewer: new TicketReviewer({ logger }),
+  acceptanceTestRunner: new AcceptanceTestRunner({ executor: new StubAcceptanceTestExecutor(), logger }),
   workloadAdapters,
   workloadAdapterRepository,
   logger 

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -5,6 +5,7 @@ import type { SkillRunner } from "../execution/skill-runner.js";
 import type { WorkloadAdapterRegistry } from "../workload/adapter-registry.js";
 import type { WorkloadTicket } from "../workload/types.js";
 import type { StandupGenerator } from "../standup/standup-generator.js";
+import type { AcceptanceTestRunner } from "../acceptance/test-runner.js";
 import type { TicketReviewer } from "../review/ticket-reviewer.js";
 
 export interface RoutesDeps {
@@ -28,6 +29,7 @@ export interface RoutesDeps {
   readonly workloadAdapterRepository?: WorkloadAdapterRepository;
   readonly standupGenerator?: StandupGenerator;
   readonly ticketReviewer?: TicketReviewer;
+  readonly acceptanceTestRunner?: AcceptanceTestRunner;
   readonly logger: Logger;
 }
 
@@ -918,6 +920,41 @@ export function createApiRouter(deps: RoutesDeps): Router {
     } catch (error) {
       const message = error instanceof Error ? error.message : "Unknown error";
       deps.logger.error({ error }, "Failed to review workload tickets");
+      res.status(500).json({ error: message });
+    }
+  });
+
+  // Acceptance testing
+  router.post("/workload/tickets/:id/acceptance-test", async (req: Request, res: Response) => {
+    if (!deps.acceptanceTestRunner) {
+      res.status(503).json({ error: "Acceptance test runner is not configured" });
+      return;
+    }
+
+    const activeAdapter = deps.workloadAdapters?.getActiveAdapter();
+    if (!activeAdapter) {
+      res.status(503).json({ error: "No active workload adapter configured" });
+      return;
+    }
+
+    try {
+      const ticket = await activeAdapter.getTicket(req.params.id);
+      if (!ticket) {
+        res.status(404).json({ error: "Ticket not found" });
+        return;
+      }
+
+      const { navigationSkill } = req.body as { navigationSkill?: string };
+      const summary = await deps.acceptanceTestRunner.run(
+        ticket.id,
+        ticket.title,
+        ticket.description ?? "",
+        navigationSkill
+      );
+      res.json(summary);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      deps.logger.error({ error, ticketId: req.params.id }, "Failed to run acceptance test");
       res.status(500).json({ error: message });
     }
   });


### PR DESCRIPTION
Acceptance testing framework that parses ticket AC and runs them through pluggable executors.

- **AC Parser**: extracts Given/When/Then + bullet-point criteria from descriptions
- **AcceptanceTestRunner**: orchestrates execution, generates markdown reports
- **StubAcceptanceTestExecutor**: default (marks as skipped) — swap in Playwright later
- **POST /api/workload/tickets/:id/acceptance-test**: trigger tests per ticket
- 5 tests, 191 total passing

V1 proves the pipeline end-to-end. Swap StubExecutor for a Playwright executor to go live.

Closes #95